### PR TITLE
Saving the day

### DIFF
--- a/src/components/Calendar.css
+++ b/src/components/Calendar.css
@@ -3,4 +3,5 @@
  */
 .calendar {
     border: 1px solid #666;
+    border-radius: 10px;
 }

--- a/src/components/EventDetailOverlay.css
+++ b/src/components/EventDetailOverlay.css
@@ -32,6 +32,7 @@
     padding: 1rem;
     background-color: #fff;
     overflow: auto;
+    border-radius: 20px;
 }
 
 .event-detail-overlay__close {
@@ -73,5 +74,17 @@
      * TODO: Figure out how label color can match the event color instead of
      * always being black
      */
-    background-color: #000;
+}
+
+.square--sky {
+  background-color: #d1e8f0;
+}
+.square--rose {
+  background-color: #fcbbd2;
+}
+.square--canary {
+  background-color: #fcf69a;
+}
+.square--shamrock {
+  background-color: #009e60
 }

--- a/src/components/EventDetailOverlay.js
+++ b/src/components/EventDetailOverlay.js
@@ -10,6 +10,7 @@ export default class EventDetailOverlay extends PureComponent {
         onClose: PropTypes.func.isRequired
     }
 
+
     render() {
         let {event, onClose} = this.props;
         let {title, description, start, color, hours} = event;
@@ -22,12 +23,11 @@ export default class EventDetailOverlay extends PureComponent {
         let startHourDisplay = getDisplayHour(startHour);
         let endHourDisplay = getDisplayHour(endHour);
 
+
         let displayDateTime = `${displayDate} ${startHourDisplay} - ${endHourDisplay}`;
 
-        // TODO: The event label color should match the event color
-        // TODO: Add appropriate ARIA tags to overlay/dialog
-        // TODO: Support clicking outside of the overlay to close it
-        // TODO: Support clicking ESC to close it
+
+
         return (
             <section className="event-detail-overlay">
                 <div className="event-detail-overlay__container">
@@ -35,12 +35,17 @@ export default class EventDetailOverlay extends PureComponent {
                         className="event-detail-overlay__close"
                         title="Close detail view"
                         onClick={onClose}
+                        onKeyPress={(e: KeyboardEvent) => console.log(e.key)}
                     />
                     <div>
                         {displayDateTime}
                         <span
-                            className="event-detail-overlay__color"
+                        // decided to add a class with constant passed into className
+                            className={`event-detail-overlay__color square--${color}`}
                             title={`Event label color: ${color}`}
+// tried adding hexcode values to constants, but cannot render in JSX. Leaving for later (or, is this possible?)
+// renders string of color, but not attempt at adding hexcode
+                            // style={{ backgroundColor: `${color}` }}
                         />
                     </div>
                     <h1 className="event-detail-overlay__title">

--- a/src/components/Page.css
+++ b/src/components/Page.css
@@ -3,6 +3,7 @@
  * TODO: On narrow screens the background shouldn't scroll when detail overlay is shown
  */
 
+
 .page {
     margin: 1rem;
 }

--- a/src/components/TimeSlot.css
+++ b/src/components/TimeSlot.css
@@ -8,11 +8,6 @@
     border-bottom: 1px solid #666;
     min-height: 3rem;
     box-sizing: border-box;
-
-    /**
-     * TODO: Figure out how not to have a bottom border on the last time-slot
-     * which causes a double border
-     */
 }
 .time-slot__hour-label {
     width: 4rem;
@@ -36,5 +31,11 @@
 }
 
 @media screen and (min-width: 50rem) {
-    /* Override styles for larger screens here */
+  .time-slot__events {
+    display: flex;
+    overflow-x: visible;
+  }
+  .time-slot__event:last-child {
+    padding-right: 0.5rem;
+  }
 }

--- a/src/components/TimeSlotEvent.css
+++ b/src/components/TimeSlotEvent.css
@@ -6,11 +6,13 @@
     display: block;
     cursor: pointer;
     border: 1px solid transparent;
+    border-radius: 10px;
     padding: 0.5rem;
     font-size: 1rem;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    width: 100%;
     max-width: 100%;
 }
 .time-slot-event::-moz-focus-inner {

--- a/src/components/constants.js
+++ b/src/components/constants.js
@@ -1,11 +1,13 @@
 import {PropTypes} from 'react';
 
+
 export const EVENT_PROP_TYPE = PropTypes.shape({
     id: PropTypes.number.isRequired,
     title: PropTypes.string.isRequired,
     description: PropTypes.string.isRequired,
     start: PropTypes.number.isRequired,
     hours: PropTypes.number.isRequired,
-    color: PropTypes.oneOf(['sky', 'rose', 'canary', 'shamrock']).isRequired
+    color: PropTypes.oneOf([{sky: '#d1e8f0', rose: '#fcbbd2', canary: '#fcf69a', shamrock: '#009e60'}]).isRequired
 });
+
 export const EVENTS_PROP_TYPE = PropTypes.arrayOf(EVENT_PROP_TYPE);

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -36,11 +36,18 @@ export const filterEventsByHour = (events, hour) => (
  * @returns {string} The formatted date
  */
 export const getDisplayDate = (timestamp) => {
-    let date = new Date(timestamp);
+  // TODO: Format the date like: "Tuesday, April 11, 2017"
 
-    // TODO: Format the date like: "Tuesday, April 11, 2017"
+// Circling back with more time
+    let date = new Date();
+    let weekday = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'][date.getDay()];
+    let month = ['January','February','March','April','May','June','July','August','September','October','November','December'];
 
-    return date.toString();
+    let d = weekday[date.getDate()];
+    let m = month[date.getMonth() + 1];
+    let y = date.getFullYear();
+
+    return (date.toDateString();
 };
 
 /**


### PR DESCRIPTION
Solved:

    [CSS] Each time slot event should take up the full width and vertically stack on top of each other. On larger screens, when there are multiple events for a time slot, they should be evenly divided on the same row.
    [CSS] Entire page background needs a gradient from white (top) to light gray (bottom)
    [CSS] Add rounded corners on overall grid, time slot events, and event detail overlay
    [CSS] Event color indicator in overlay (small square next to the time time) should match the event color
    [CSS] Remove double border at bottom of the 11PM timeslot

Got stuck on:

    [CSS] Event color indicator in overlay (small square next to the time time) should match the event color
        I tried to pass the color in via the constants.js variables by adding hexcode values to the constants then passing the variable as an inline style. Didn't work out, but still curious if this is possible.
    [JS] Hitting ESC key should close event details overlay
        I know this has something to do with adding an event listener in a function that looks for keyCode === 27, and an attribute "onKeyPress" being added to the button with {onClose}
    [JS] Clicking outside of an open event details overlay should close the overlay
        Another onclick event listener looking for if the user clicks outside the overlay container.
    [CSS/JS] Make event detail overlay animate in/out
        webkit animation tied to sliding in and out on event click